### PR TITLE
Don't hard code WS version in tests

### DIFF
--- a/lib/src/kbaserelationengine/main/MainObjectProcessor.java
+++ b/lib/src/kbaserelationengine/main/MainObjectProcessor.java
@@ -68,7 +68,6 @@ import us.kbase.common.service.UnauthorizedException;
 import workspace.GetObjectInfo3Params;
 import workspace.ObjectData;
 import workspace.ObjectSpecification;
-import workspace.SetPermissionsParams;
 import workspace.WorkspaceClient;
 
 public class MainObjectProcessor {
@@ -398,20 +397,6 @@ public class MainObjectProcessor {
         indexingStorage.unpublishObjects(new LinkedHashSet<>(Arrays.asList(guid)));
     }
 
-    public void addWorkspaceToIndex(String wsNameOrId, AuthToken user)
-            throws IOException, JsonClientException {
-        WorkspaceClient wsClient = new WorkspaceClient(wsURL, user);
-        wsClient.setIsInsecureHttpConnectionAllowed(true); 
-        SetPermissionsParams params = new SetPermissionsParams();
-        try {
-            params.setId(Long.parseLong(wsNameOrId));
-        } catch (NumberFormatException e) {
-            params.setWorkspace(wsNameOrId);
-        }
-        wsClient.setPermissions(params.withUsers(
-                Arrays.asList(kbaseIndexerToken.getUserName())).withNewPermission("w"));
-    }
-    
     public IndexingStorage getIndexingStorage(String objectType) {
         return indexingStorage;
     }

--- a/test/src/kbaserelationengine/main/test/MainObjectProcessorTest.java
+++ b/test/src/kbaserelationengine/main/test/MainObjectProcessorTest.java
@@ -98,7 +98,7 @@ public class MainObjectProcessorTest {
         
         // set up Workspace
         ws = new WorkspaceController(
-                "0.7.2-dev1",
+                TestCommon.getWorkspaceVersion(),
                 TestCommon.getJarsDir(),
                 "localhost:" + mongo.getServerPort(), "MOPTestWSDB",
                     kbaseIndexerToken.getUserName(),

--- a/test/src/kbaserelationengine/test/common/TestCommon.java
+++ b/test/src/kbaserelationengine/test/common/TestCommon.java
@@ -33,6 +33,8 @@ public class TestCommon {
     
     public static final String JARS_PATH = "test.jars.dir";
     public static final String JARS_PATH_DEFAULT = "/kb/deployment/lib/jars";
+    public static final String WS_VER = "test.workspace.ver";
+    public static final String WS_VER_DEFAULT = "0.7.2-dev1";
     
     public static final String AUTHSERV = "auth_service_url";
     public static final String TEST_TOKEN = "test_token";
@@ -139,6 +141,10 @@ public class TestCommon {
     
     public static Path getJarsDir() {
         return Paths.get(getTestProperty(JARS_PATH, JARS_PATH_DEFAULT));
+    }
+    
+    public static String getWorkspaceVersion() {
+        return getTestProperty(WS_VER, WS_VER_DEFAULT);
     }
     
     public static URL getAuthUrl() {


### PR DESCRIPTION
The deleted method is unused. Evidence: 1) Eclipse search doesn't find
any usage, 2) code compiles. The method is deleted because its name
does not reflect what it does and the indexer should not be making
changes to the workspace anyway.