### PR TITLE
WIP: Switch to ws admin methods

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -1,5 +1,5 @@
 [ {
   "module_name" : "Workspace",
   "type" : "core",
-  "file_path" : "https://raw.githubusercontent.com/kbase/workspace_deluxe/master/workspace.spec"
+  "file_path" : "https://raw.githubusercontent.com/kbase/workspace_deluxe/dev-candidate/workspace.spec"
 } ]

--- a/lib/src/kbaserelationengine/events/handler/WorkspaceEventHandler.java
+++ b/lib/src/kbaserelationengine/events/handler/WorkspaceEventHandler.java
@@ -3,17 +3,22 @@ package kbaserelationengine.events.handler;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+
 import kbaserelationengine.events.ObjectStatusEvent;
 import kbaserelationengine.events.ObjectStatusEventType;
 import us.kbase.common.service.JsonClientException;
 import us.kbase.common.service.Tuple11;
+import us.kbase.common.service.UObject;
 import workspace.GetObjectInfo3Params;
+import workspace.GetObjectInfo3Results;
 import workspace.ListObjectsParams;
 import workspace.ObjectIdentity;
 import workspace.ObjectSpecification;
@@ -25,13 +30,17 @@ import workspace.WorkspaceClient;
  */
 public class WorkspaceEventHandler implements EventHandler {
     
-    //TODO JAVADOC
     //TODO TEST will need to mock the ws client
 
     /** The storage code for workspace events. */
     public static final String STORAGE_CODE = "WS";
     
     private static final int WS_BATCH_SIZE = 10_000;
+    
+    private static final TypeReference<List<Tuple11<Long, String, String, String,
+            Long, String, Long, String, String, Long, Map<String, String>>>> OBJ_TYPEREF =
+                    new TypeReference<List<Tuple11<Long, String, String, String,
+                        Long, String, Long, String, String, Long, Map<String, String>>>>() {};
     
     private final WorkspaceClient ws;
     
@@ -44,6 +53,10 @@ public class WorkspaceEventHandler implements EventHandler {
 
     @Override
     public Iterable<ObjectStatusEvent> expand(final ObjectStatusEvent event) {
+        if (!STORAGE_CODE.equals(event.getStorageCode())) {
+            throw new IllegalArgumentException("This handler only accepts "
+                    + STORAGE_CODE + "events");
+        }
         if (ObjectStatusEventType.NEW_ALL_VERSIONS.equals(event.getEventType())) {
             return handleNewAllVersions(event);
         } else if (ObjectStatusEventType.COPY_ACCESS_GROUP.equals(event.getEventType())) {
@@ -102,13 +115,16 @@ public class WorkspaceEventHandler implements EventHandler {
             // ws asc, obj id asc, ver dec
             
             final ArrayList<ObjectStatusEvent> events;
+            final Map<String, Object> command = new HashMap<>();
+            command.put("command", "listObjects");
+            command.put("params", new ListObjectsParams()
+                    .withIds(Arrays.asList((long) accessGroupId))
+                    .withMinObjectID((long) processedObjs + 1)
+                    .withShowHidden(1L)
+                    .withShowAllVersions(1L));
             try {
-                events = buildEvents(sourceEvent,
-                        ws.listObjects(new ListObjectsParams()
-                                .withIds(Arrays.asList((long) accessGroupId))
-                                .withMinObjectID((long) processedObjs + 1)
-                                .withShowHidden(1L)
-                                .withShowAllVersions(1L)));
+                events = buildEvents(sourceEvent, ws.administer(new UObject(command))
+                        .asClassInstance(OBJ_TYPEREF));
             } catch (JsonClientException | IOException e) {
                 //TODO EXP some of these exceptions should be retries, some should shut down the event loop until the issue can be fixed (e.g. bad token, ws down), some should ignore the event (ws deleted)
                 throw new IllegalStateException("Error contacting workspace: " + e.getMessage(),
@@ -161,10 +177,12 @@ public class WorkspaceEventHandler implements EventHandler {
                         .withObjid(objectID)
                         .withVer((long) ver));
             }
+            final Map<String, Object> command = new HashMap<>();
+            command.put("command", "getObjectInfo");
+            command.put("params", new GetObjectInfo3Params().withObjects(objs));
             try {
-                queue.addAll(buildEvents(sourceEvent,
-                        ws.getObjectInfo3(new GetObjectInfo3Params()
-                                .withObjects(objs)).getInfos()));
+                queue.addAll(buildEvents(sourceEvent, ws.administer(new UObject(command))
+                        .asClassInstance(GetObjectInfo3Results.class).getInfos()));
             } catch (JsonClientException | IOException e) {
                 //TODO EXP some of these exceptions should be retries, some should shut down the event loop until the issue can be fixed (e.g. bad token, ws down), some should ignore the event (ws deleted)
                 throw new IllegalStateException("Error contacting workspace: " + e.getMessage(),
@@ -182,11 +200,14 @@ public class WorkspaceEventHandler implements EventHandler {
             throw new IllegalStateException("Illegal workspace object id: " +
                     event.getAccessGroupObjectId());
         }
+        final Map<String, Object> command = new HashMap<>();
+        command.put("command", "getObjectHistory");
+        command.put("params", new ObjectIdentity()
+                .withWsid((long) event.getAccessGroupId())
+                .withObjid(objid));
         try {
-            return buildEvents(event, 
-                    ws.getObjectHistory(new ObjectIdentity()
-                            .withWsid((long) event.getAccessGroupId())
-                            .withObjid(objid)));
+            return buildEvents(event, ws.administer(new UObject(command))
+                    .asClassInstance(OBJ_TYPEREF));
         } catch (JsonClientException | IOException e) {
             //TODO EXP some of these exceptions should be retries, some should shut down the event loop until the issue can be fixed (e.g. bad token, ws down), some should cause the event to be ignored (deleted object)
             throw new IllegalStateException("Error contacting workspace: " + e.getMessage(),

--- a/lib/src/kbaserelationengine/main/MainObjectProcessor.java
+++ b/lib/src/kbaserelationengine/main/MainObjectProcessor.java
@@ -6,6 +6,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -68,6 +69,7 @@ import us.kbase.common.service.JsonClientException;
 import us.kbase.common.service.UObject;
 import us.kbase.common.service.UnauthorizedException;
 import workspace.GetObjectInfo3Params;
+import workspace.GetObjectInfo3Results;
 import workspace.ObjectData;
 import workspace.ObjectSpecification;
 import workspace.WorkspaceClient;
@@ -379,6 +381,7 @@ public class MainObjectProcessor {
                     guid.getVersion();
             String nextCallerRefPath = (callerRefPath == null || callerRefPath.isEmpty() ? "" : 
                 (callerRefPath + ";")) + objRef;
+            //TODO HANDLER move this into handler API
             /* ideally here you would select an implementation of an EventHandler
              * based on the storageCode that knows how to fetch the data you need based on the
              * nextCallerRefPath
@@ -735,8 +738,12 @@ public class MainObjectProcessor {
                     List<ObjectSpecification> getInfoInput = refs.stream().map(
                             ref -> new ObjectSpecification().withRef(refPrefix + ref)).collect(
                                     Collectors.toList());
-                    List<ObjectStatusEvent> events = wsClient.getObjectInfo3(
-                            new GetObjectInfo3Params().withObjects(getInfoInput))
+                    //TODO HANDLER move this to the handler api
+                    final Map<String, Object> command = new HashMap<>();
+                    command.put("command", "getObjectInfo");
+                    command.put("params", new GetObjectInfo3Params().withObjects(getInfoInput));
+                    List<ObjectStatusEvent> events = wsClient.administer(new UObject(command))
+                            .asClassInstance(GetObjectInfo3Results.class)
                             .getInfos().stream().map(info -> new ObjectStatusEvent("", "WS", 
                                     (int)(long)info.getE7(), "" +info.getE1(), 
                                     (int)(long)info.getE5(), null, Util.DATE_PARSER.parseDateTime(

--- a/lib/src/kbaserelationengine/parse/ObjectParser.java
+++ b/lib/src/kbaserelationengine/parse/ObjectParser.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ import us.kbase.auth.AuthToken;
 import us.kbase.common.service.JsonClientException;
 import us.kbase.common.service.UObject;
 import workspace.GetObjects2Params;
+import workspace.GetObjects2Results;
 import workspace.ObjectData;
 import workspace.ObjectSpecification;
 import workspace.WorkspaceClient;
@@ -44,8 +46,12 @@ public class ObjectParser {
         wc.setIsInsecureHttpConnectionAllowed(true);
         wc.setStreamingModeOn(true);
         wc._setFileForNextRpcResponse(tempFile);
-        return wc.getObjects2(new GetObjects2Params().withObjects(
-                Arrays.asList(new ObjectSpecification().withRef(objRef)))).getData().get(0);
+        final Map<String, Object> command = new HashMap<>();
+        command.put("command", "getObjects");
+        command.put("params", new GetObjects2Params().withObjects(
+                Arrays.asList(new ObjectSpecification().withRef(objRef))));
+        return wc.administer(new UObject(command)).asClassInstance(GetObjects2Results.class)
+                .getData().get(0);
     }
     
     public static Map<GUID, String> parseSubObjects(ObjectData obj, String objRef, 

--- a/lib/src/kbaserelationengine/search/ElasticIndexingStorage.java
+++ b/lib/src/kbaserelationengine/search/ElasticIndexingStorage.java
@@ -676,6 +676,11 @@ public class ElasticIndexingStorage implements IndexingStorage {
     }
 
     @Override
+    public void setNameOnAllObjectVersions(final GUID object, final String newName) {
+        //TODO NOW fill in
+    }
+    
+    @Override
     public void shareObjects(Set<GUID> guids, int accessGroupId) throws IOException {
         Map<String, Set<GUID>> indexToGuids = groupParentIdsByIndex(guids);
         for (String indexName : indexToGuids.keySet()) {

--- a/lib/src/kbaserelationengine/search/IndexingStorage.java
+++ b/lib/src/kbaserelationengine/search/IndexingStorage.java
@@ -55,4 +55,10 @@ public interface IndexingStorage {
     public FoundHits searchObjects(String objectType, MatchFilter matchFilter, 
             List<SortingRule> sorting, AccessFilter accessFilter, Pagination pagination,
             PostProcessing postProcessing) throws IOException;
+
+    /** Change the name of all the versions of an object.
+     * @param object the GUID of the object. The version field is ignored.
+     * @param newName the new name of the object.
+     */
+    void setNameOnAllObjectVersions(GUID object, String newName);
 }

--- a/lib/src/workspace/ListWorkspaceIDsParams.java
+++ b/lib/src/workspace/ListWorkspaceIDsParams.java
@@ -1,0 +1,105 @@
+
+package workspace;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ListWorkspaceIDsParams</p>
+ * <pre>
+ * Input parameters for the "list_workspace_ids" function.
+ * Optional parameters:
+ * permission perm - filter workspaces by minimum permission level. 'None'
+ *         and 'readable' are ignored.
+ * boolean onlyGlobal - if onlyGlobal is true only include world readable
+ *         workspaces. Defaults to false. If true, excludeGlobal is ignored.
+ * boolean excludeGlobal - if excludeGlobal is true exclude world
+ *         readable workspaces. Defaults to true.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "perm",
+    "excludeGlobal",
+    "onlyGlobal"
+})
+public class ListWorkspaceIDsParams {
+
+    @JsonProperty("perm")
+    private String perm;
+    @JsonProperty("excludeGlobal")
+    private Long excludeGlobal;
+    @JsonProperty("onlyGlobal")
+    private Long onlyGlobal;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("perm")
+    public String getPerm() {
+        return perm;
+    }
+
+    @JsonProperty("perm")
+    public void setPerm(String perm) {
+        this.perm = perm;
+    }
+
+    public ListWorkspaceIDsParams withPerm(String perm) {
+        this.perm = perm;
+        return this;
+    }
+
+    @JsonProperty("excludeGlobal")
+    public Long getExcludeGlobal() {
+        return excludeGlobal;
+    }
+
+    @JsonProperty("excludeGlobal")
+    public void setExcludeGlobal(Long excludeGlobal) {
+        this.excludeGlobal = excludeGlobal;
+    }
+
+    public ListWorkspaceIDsParams withExcludeGlobal(Long excludeGlobal) {
+        this.excludeGlobal = excludeGlobal;
+        return this;
+    }
+
+    @JsonProperty("onlyGlobal")
+    public Long getOnlyGlobal() {
+        return onlyGlobal;
+    }
+
+    @JsonProperty("onlyGlobal")
+    public void setOnlyGlobal(Long onlyGlobal) {
+        this.onlyGlobal = onlyGlobal;
+    }
+
+    public ListWorkspaceIDsParams withOnlyGlobal(Long onlyGlobal) {
+        this.onlyGlobal = onlyGlobal;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("ListWorkspaceIDsParams"+" [perm=")+ perm)+", excludeGlobal=")+ excludeGlobal)+", onlyGlobal=")+ onlyGlobal)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/workspace/ListWorkspaceIDsResults.java
+++ b/lib/src/workspace/ListWorkspaceIDsResults.java
@@ -1,0 +1,85 @@
+
+package workspace;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ListWorkspaceIDsResults</p>
+ * <pre>
+ * Results of the "list_workspace_ids" function.
+ * list<int> workspaces - the workspaces to which the user has explicit
+ *         access.
+ * list<int> pub - the workspaces to which the user has access because
+ *         they're globally readable.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "workspaces",
+    "pub"
+})
+public class ListWorkspaceIDsResults {
+
+    @JsonProperty("workspaces")
+    private List<Long> workspaces;
+    @JsonProperty("pub")
+    private List<Long> pub;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("workspaces")
+    public List<Long> getWorkspaces() {
+        return workspaces;
+    }
+
+    @JsonProperty("workspaces")
+    public void setWorkspaces(List<Long> workspaces) {
+        this.workspaces = workspaces;
+    }
+
+    public ListWorkspaceIDsResults withWorkspaces(List<Long> workspaces) {
+        this.workspaces = workspaces;
+        return this;
+    }
+
+    @JsonProperty("pub")
+    public List<Long> getPub() {
+        return pub;
+    }
+
+    @JsonProperty("pub")
+    public void setPub(List<Long> pub) {
+        this.pub = pub;
+    }
+
+    public ListWorkspaceIDsResults withPub(List<Long> pub) {
+        this.pub = pub;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("ListWorkspaceIDsResults"+" [workspaces=")+ workspaces)+", pub=")+ pub)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/workspace/ObjectSaveData.java
+++ b/lib/src/workspace/ObjectSaveData.java
@@ -21,14 +21,12 @@ import us.kbase.common.service.UObject;
  *         type_string type - the type of the object. Omit the version information
  *                 to use the latest version.
  *         UnspecifiedObject data - the object data.
+ *         One, and only one, of:
+ *                 obj_name name - the name of the object.
+ *                 obj_id objid - the id of the object to save over.
+ *         
  *         
  *         Optional arguments:
- *         One of an object name or id. If no name or id is provided the name
- *                 will be set to 'auto' with the object id appended as a string,
- *                 possibly with -\d+ appended if that object id already exists as a
- *                 name.
- *         obj_name name - the name of the object.
- *         obj_id objid - the id of the object to save over.
  *         usermeta meta - arbitrary user-supplied metadata for the object,
  *                 not to exceed 16kb; if the object type specifies automatic
  *                 metadata extraction with the 'meta ws' annotation, and your

--- a/lib/src/workspace/WorkspaceClient.java
+++ b/lib/src/workspace/WorkspaceClient.java
@@ -697,6 +697,26 @@ public class WorkspaceClient {
     }
 
     /**
+     * <p>Original spec-file function name: list_workspace_ids</p>
+     * <pre>
+     * List workspace IDs to which the user has access.
+     * This function returns a subset of the information in the
+     * list_workspace_info method and should be substantially faster.
+     * </pre>
+     * @param   params   instance of type {@link workspace.ListWorkspaceIDsParams ListWorkspaceIDsParams}
+     * @return   parameter "results" of type {@link workspace.ListWorkspaceIDsResults ListWorkspaceIDsResults}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public ListWorkspaceIDsResults listWorkspaceIds(ListWorkspaceIDsParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<ListWorkspaceIDsResults>> retType = new TypeReference<List<ListWorkspaceIDsResults>>() {};
+        List<ListWorkspaceIDsResults> res = caller.jsonrpcCall("Workspace.list_workspace_ids", args, retType, true, false, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
      * <p>Original spec-file function name: list_workspace_objects</p>
      * <pre>
      * Lists the metadata of all objects in the specified workspace with the

--- a/test/src/kbaserelationengine/test/common/TestCommon.java
+++ b/test/src/kbaserelationengine/test/common/TestCommon.java
@@ -38,6 +38,7 @@ public class TestCommon {
     
     public static final String AUTHSERV = "auth_service_url";
     public static final String TEST_TOKEN = "test_token";
+    public static final String TEST_TOKEN2 = "test.token2";
     public static final String GLOBUS = "test.globus.url";
     public static final String GLOBUS_DEFAULT =
             "https://ci.kbase.us/services/auth/api/legacy/Globus";
@@ -171,6 +172,20 @@ public class TestCommon {
             final ConfigurableAuthService auth) {
         try {
             return auth.validateToken(getToken());
+        } catch (AuthException | IOException e) {
+            throw new TestException(String.format(
+                    "Couldn't log in user with token : %s", e.getMessage()), e);
+        }
+    }
+    
+    public static String getToken2() {
+        return getTestProperty(TEST_TOKEN2);
+    }
+    
+    public static AuthToken getToken2(
+            final ConfigurableAuthService auth) {
+        try {
+            return auth.validateToken(getToken2());
         } catch (AuthException | IOException e) {
             throw new TestException(String.format(
                     "Couldn't log in user with token : %s", e.getMessage()), e);

--- a/test/src/kbaserelationengine/test/controllers/workspace/WorkspaceController.java
+++ b/test/src/kbaserelationengine/test/controllers/workspace/WorkspaceController.java
@@ -85,7 +85,7 @@ public class WorkspaceController {
         env.put("KB_DEPLOYMENT_CONFIG", deployCfg.toString());
         
         workspace = servpb.start();
-        Thread.sleep(2000); //wait for server to start up
+        Thread.sleep(5000); //wait for server to start up
     }
 
     private Path createDeployCfg(


### PR DESCRIPTION
NOTE: no changes were made to the reconstructor

Added a test.token2 property required in test.cfg to separate the
standard and admin users.

TODO
* [x] test the WorkspaceEventHandler manually since there are no tests
for that yet