### PR TITLE
TASK-895 Add access group id cache & workspace provider implementation

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -27,5 +27,10 @@
 	<classpathentry kind="lib" path="lib/jars/mongodb/mongo-java-driver-3.4.2.jar"/>
 	<classpathentry kind="lib" path="lib/jars/apache_commons/commons-codec-1.10.jar"/>
 	<classpathentry kind="lib" path="/jars/lib/jars/slf4j/slf4j-api-1.7.25.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/google/guava-18.0.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/mockito/mockito-core-2.7.10.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-1.6.8.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/bytebuddy/byte-buddy-agent-1.6.8.jar"/>
+	<classpathentry kind="lib" path="/jars/lib/jars/objenesis/objenesis-2.5.1.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/KBaseRelationEngine.spec
+++ b/KBaseRelationEngine.spec
@@ -20,7 +20,7 @@ module KBaseRelationEngine {
       In case of range constraint rather than single value 'min_*' 
       and 'max_*' fields should be used. You may omit one of ends of
       range to achieve '<=' or '>=' comparison. Ends are always
-      included for range constrains.
+      included for range constraints.
     */
     typedef structure {
         string value;

--- a/build.xml
+++ b/build.xml
@@ -38,6 +38,12 @@
     <include name="kbase/workspace/WorkspaceClient-0.6.0.jar"/>
     <include name="apache_commons/commons-logging-1.1.1.jar"/>
     <include name="apache_commons/commons-io-2.4.jar"/>
+    <include name="google/guava-18.0.jar"/>
+    <!-- mockito and dependencies -->
+    <include name="mockito/mockito-core-2.7.10.jar"/>
+    <include name="bytebuddy/byte-buddy-1.6.8.jar"/>
+    <include name="bytebuddy/byte-buddy-agent-1.6.8.jar"/>
+    <include name="objenesis/objenesis-2.5.1.jar"/>
   </fileset>
 
   <fileset dir="lib/jars" id="lib2">
@@ -128,6 +134,7 @@ java -Xmx2g -cp ${jar.absolute.path}:${lib.classpath} kbaserelationengine.main.t
       <batchtest>
         <fileset dir="${test.src}">
           <include name="kbaserelationengine/parse/test/**Test.java"/>
+          <include name="kbaserelationengine/events/AccessGroupCacheTest.java"/>
           <include name="kbaserelationengine/events/storage/MongoDBStatusEventStorageTest.java"/>
           <include name="kbaserelationengine/queue/test/ObjectStatusEventQueueTest.java"/>
           <include name="kbaserelationengine/search/test/ElasticIndexingStorageTest.java"/>

--- a/lib/src/kbaserelationengine/events/AccessGroupCache.java
+++ b/lib/src/kbaserelationengine/events/AccessGroupCache.java
@@ -1,0 +1,93 @@
+package kbaserelationengine.events;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Ticker;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.Weigher;
+
+/** A caching layer for access groups. Caches the results from the wrapped
+ * {@link AccessGroupProvider} in memory for quick access.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class AccessGroupCache implements AccessGroupProvider {
+    
+    private final LoadingCache<String, List<Integer>> cache;
+    
+    /** Create a cache.
+     * @param provider the {@link AccessGroupProvider} whose results will be cached.
+     * @param cacheLifeTimeInSec the number of seconds a set of access groups for a user should
+     * remain in the cache.
+     * @param cacheSizeInAccessGroups the maximum number of access groups, across all users, to
+     * store in the cache.
+     */
+    public AccessGroupCache(
+            final AccessGroupProvider provider,
+            final int cacheLifeTimeInSec,
+            final int cacheSizeInAccessGroups) {
+        this(provider, cacheLifeTimeInSec, cacheSizeInAccessGroups, Ticker.systemTicker());
+    }
+    
+    /** Create a cache for testing purposes.
+     * @param provider the {@link AccessGroupProvider} whose results will be cached.
+     * @param cacheLifeTimeInSec the number of seconds an set of access groups for a user should
+     * remain in the cache.
+     * @param cacheSizeInAccessGroups the maximum number of access groups, across all users, to
+     * store in the cache.
+     * @param ticker a ticker implementation that allows controlling cache expiration with the
+     * provided ticker rather than waiting for the system clock. This is exposed for testing
+     * purposes.
+     */
+    public AccessGroupCache(
+            final AccessGroupProvider provider,
+            final int cacheLifeTimeInSec,
+            final int cacheSizeInAccessGroups,
+            final Ticker ticker) {
+        if (provider == null) {
+            throw new NullPointerException("provider");
+        }
+        if (cacheLifeTimeInSec < 1) {
+            throw new IllegalArgumentException("cache lifetime must be at least one second");
+        }
+        if (cacheSizeInAccessGroups < 1) {
+            throw new IllegalArgumentException("cache size must be at least one");
+        }
+        cache = CacheBuilder.newBuilder()
+                .ticker(ticker)
+                .expireAfterWrite(cacheLifeTimeInSec, TimeUnit.SECONDS)
+                .maximumWeight(cacheSizeInAccessGroups)
+                .weigher(new Weigher<String, List<Integer>>() {
+
+                    @Override
+                    public int weigh(String user, List<Integer> accessGroups) {
+                        return accessGroups.size();
+                    }
+                    
+                })
+                .build(new CacheLoader<String, List<Integer>>() {
+
+                    @Override
+                    public List<Integer> load(String user) throws Exception {
+                        return provider.findAccessGroupIds(user);
+                    }
+
+                });
+    }
+
+    @Override
+    public List<Integer> findAccessGroupIds(final String user) throws IOException {
+        try {
+            return cache.get(user);
+        } catch (ExecutionException e) {
+            throw (IOException) e.getCause(); // IOE is the only checked exception
+            // unchecked exceptions are wrapped in UncheckedExcecutionException
+        }
+    }
+
+}

--- a/lib/src/kbaserelationengine/events/AccessGroupProvider.java
+++ b/lib/src/kbaserelationengine/events/AccessGroupProvider.java
@@ -4,6 +4,6 @@ import java.io.IOException;
 import java.util.List;
 
 public interface AccessGroupProvider {
-	public List<Integer> findAccessGroupIds(String storageCode, String user) throws IOException;	
+	public List<Integer> findAccessGroupIds(String user) throws IOException;
 
 }

--- a/lib/src/kbaserelationengine/events/WorkspaceAccessGroupProvider.java
+++ b/lib/src/kbaserelationengine/events/WorkspaceAccessGroupProvider.java
@@ -1,0 +1,50 @@
+package kbaserelationengine.events;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.google.common.collect.ImmutableMap;
+
+import us.kbase.common.service.JsonClientException;
+import us.kbase.common.service.UObject;
+import workspace.ListWorkspaceIDsParams;
+import workspace.ListWorkspaceIDsResults;
+import workspace.WorkspaceClient;
+
+/** A provider for KBase workspace service based access group IDs.
+ * @author gaprice@lbl.gov
+ *
+ */
+public class WorkspaceAccessGroupProvider implements AccessGroupProvider {
+    
+    //TODO TEST
+    
+    private final WorkspaceClient ws;
+    
+    /** Create the provider.
+     * @param adminClient a workspace client initialized with administrator credentials.
+     */
+    public WorkspaceAccessGroupProvider(final WorkspaceClient adminClient) {
+        if (adminClient == null) {
+            throw new NullPointerException("adminClient");
+        }
+        this.ws = adminClient;
+    }
+
+    @Override
+    public List<Integer> findAccessGroupIds(String user) throws IOException {
+        try {
+            return ws.administer(new UObject(ImmutableMap.of(
+                    "command", "listWorkspaceIDs",
+                    "params", new ListWorkspaceIDsParams(),
+                    "user", user)))
+                    .asClassInstance(ListWorkspaceIDsResults.class)
+                    .getWorkspaces().stream().map(l -> Math.toIntExact(l))
+                            .collect(Collectors.toList());
+        } catch (JsonClientException e) {
+            throw new IOException(e.getMessage(), e);
+        }
+    }
+
+}

--- a/lib/src/kbaserelationengine/events/storage/MongoDBStatusEventStorage.java
+++ b/lib/src/kbaserelationengine/events/storage/MongoDBStatusEventStorage.java
@@ -87,12 +87,10 @@ public class MongoDBStatusEventStorage implements AccessGroupProvider, StatusEve
 	}
 	
 	@Override
-	public List<Integer> findAccessGroupIds(String storageCode, String user){
+	public List<Integer> findAccessGroupIds(String user){
 		BasicDBList queryItems = new BasicDBList();
 		queryItems.add(new BasicDBObject("users", user));
-		if(storageCode != null){
-			queryItems.add(new BasicDBObject("storageCode", storageCode));			
-		}
+		queryItems.add(new BasicDBObject("storageCode", "WS"));
 		BasicDBObject query = new BasicDBObject("$and", queryItems);	
 		DBCursor cursor = collection(COLLECTION_GROUP_STATUS).find(query);
 				

--- a/lib/src/kbaserelationengine/main/MainObjectProcessor.java
+++ b/lib/src/kbaserelationengine/main/MainObjectProcessor.java
@@ -34,6 +34,7 @@ import kbaserelationengine.SearchTypesOutput;
 import kbaserelationengine.SortingRule;
 import kbaserelationengine.TypeDescriptor;
 import kbaserelationengine.common.GUID;
+import kbaserelationengine.events.AccessGroupCache;
 import kbaserelationengine.events.AccessGroupProvider;
 import kbaserelationengine.events.AccessGroupStatus;
 import kbaserelationengine.events.ObjectStatusEvent;
@@ -126,7 +127,8 @@ public class MainObjectProcessor {
         this.admins = admins == null ? Collections.emptySet() : admins;
         MongoDBStatusEventStorage storage = new MongoDBStatusEventStorage(mongoHost, mongoPort, mongoDbName);
         eventStorage = storage;
-        accessGroupProvider = storage;
+        // 50k simultaneous users * 1000 group ids each seems like plenty = 50M ints in memory
+        accessGroupProvider = new AccessGroupCache(storage, 30, 50000 * 1000);
         WSStatusEventReconstructorImpl reconstructor = new WSStatusEventReconstructorImpl(
                 wsURL, kbaseIndexerToken, eventStorage);
         wsClient = reconstructor.wsClient();

--- a/lib/src/kbaserelationengine/main/MainObjectProcessor.java
+++ b/lib/src/kbaserelationengine/main/MainObjectProcessor.java
@@ -40,6 +40,7 @@ import kbaserelationengine.events.AccessGroupStatus;
 import kbaserelationengine.events.ObjectStatusEvent;
 import kbaserelationengine.events.ObjectStatusEventType;
 import kbaserelationengine.events.StatusEventListener;
+import kbaserelationengine.events.WorkspaceAccessGroupProvider;
 import kbaserelationengine.events.handler.EventHandler;
 import kbaserelationengine.events.handler.WorkspaceEventHandler;
 import kbaserelationengine.events.reconstructor.AccessType;
@@ -127,11 +128,12 @@ public class MainObjectProcessor {
         this.admins = admins == null ? Collections.emptySet() : admins;
         MongoDBStatusEventStorage storage = new MongoDBStatusEventStorage(mongoHost, mongoPort, mongoDbName);
         eventStorage = storage;
-        // 50k simultaneous users * 1000 group ids each seems like plenty = 50M ints in memory
-        accessGroupProvider = new AccessGroupCache(storage, 30, 50000 * 1000);
         WSStatusEventReconstructorImpl reconstructor = new WSStatusEventReconstructorImpl(
                 wsURL, kbaseIndexerToken, eventStorage);
         wsClient = reconstructor.wsClient();
+        // 50k simultaneous users * 1000 group ids each seems like plenty = 50M ints in memory
+        accessGroupProvider = new AccessGroupCache(new WorkspaceAccessGroupProvider(wsClient),
+                30, 50000 * 1000);
         wsEventReconstructor = reconstructor;
         reconstructor.registerListener(storage);
         if (logger != null) {

--- a/lib/src/kbaserelationengine/main/MainObjectProcessor.java
+++ b/lib/src/kbaserelationengine/main/MainObjectProcessor.java
@@ -284,6 +284,7 @@ public class MainObjectProcessor {
         // Seems like this shouldn't be source specific. It should handle all event sources.
         ObjectStatusEventIterator iter = queue.iterator("WS");
         while (iter.hasNext()) {
+            //TODO NOW markAsVisited is called for every sub event, which is pointless. It should be called only when all sub events are processed.
             final ObjectStatusEvent preEvent = iter.next();
             for (final ObjectStatusEvent ev: getEventHandler(preEvent).expand(preEvent)) {
                 if (!isStorageTypeSupported(ev.getStorageObjectType())) {
@@ -526,7 +527,7 @@ public class MainObjectProcessor {
             throws IOException {
         List<Integer> accessGroupIds;
         if (toBool(af.getWithPrivate(), true)) {
-            accessGroupIds = accessGroupProvider.findAccessGroupIds("WS", user);
+            accessGroupIds = accessGroupProvider.findAccessGroupIds(user);
         } else {
             accessGroupIds = Collections.emptyList();
         }

--- a/test/src/kbaserelationengine/events/AccessGroupCacheTest.java
+++ b/test/src/kbaserelationengine/events/AccessGroupCacheTest.java
@@ -1,0 +1,169 @@
+package kbaserelationengine.events;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+
+import com.google.common.base.Ticker;
+
+import kbaserelationengine.test.common.TestCommon;
+
+public class AccessGroupCacheTest {
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void standardConstructor() throws Exception {
+        // test the non-test constructor
+        final AccessGroupProvider wrapped = mock(AccessGroupProvider.class);
+        final AccessGroupCache cache = new AccessGroupCache(wrapped, 1, 10000);
+        
+        when(wrapped.findAccessGroupIds("foo")).thenReturn(
+                Arrays.asList(1), Arrays.asList(2, 3), null);
+        
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1)));
+        Thread.sleep(1001);
+        
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(2, 3)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(2, 3)));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void expiresEveryGet() throws Exception {
+        // test that expires the value from the cache every time
+        final AccessGroupProvider wrapped = mock(AccessGroupProvider.class);
+        final Ticker ticker = mock(Ticker.class);
+        final AccessGroupCache cache = new AccessGroupCache(wrapped, 10, 10000, ticker);
+        
+        when(wrapped.findAccessGroupIds("foo")).thenReturn(
+                Arrays.asList(1), Arrays.asList(2, 3), null);
+        when(ticker.read()).thenReturn(0L, 10000000001L, 20000000001L);
+        
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1)));
+        
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(2, 3)));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void cacheAccessOnGet() throws Exception {
+        // test that the cache is accessed when available
+        final AccessGroupProvider wrapped = mock(AccessGroupProvider.class);
+        final Ticker ticker = mock(Ticker.class);
+        final AccessGroupCache cache = new AccessGroupCache(wrapped, 10, 10000, ticker);
+        
+        when(wrapped.findAccessGroupIds("foo")).thenReturn(
+                Arrays.asList(1), Arrays.asList(2, 3), null);
+        when(ticker.read()).thenReturn(0L, 5000000001L, 10000000001L, 15000000001L, 20000000001L);
+        
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1)));
+        
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(2, 3)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(2, 3)));
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Test
+    public void expiresOnSize() throws Exception {
+        // test that the cache expires values when it reaches the max size
+        final AccessGroupProvider wrapped = mock(AccessGroupProvider.class);
+        final AccessGroupCache cache = new AccessGroupCache(wrapped, 10000, 10);
+        
+        when(wrapped.findAccessGroupIds("foo")).thenReturn(
+                Arrays.asList(1, 2, 3, 4, 5), Arrays.asList(2, 3), null);
+        when(wrapped.findAccessGroupIds("bar")).thenReturn(
+                Arrays.asList(6, 7, 8, 9), Arrays.asList(11, 12), null);
+        when(wrapped.findAccessGroupIds("baz")).thenReturn(
+                Arrays.asList(20, 21), Arrays.asList(22, 23), null);
+        
+        // load 9 access group IDs into a max 10 cache
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1, 2, 3, 4, 5)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("bar"),
+                is(Arrays.asList(6, 7, 8, 9)));
+        
+        // check cache access
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(1, 2, 3, 4, 5)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("bar"),
+                is(Arrays.asList(6, 7, 8, 9)));
+        
+        // force an expiration based on cache size
+        assertThat("incorrect access groups", cache.findAccessGroupIds("baz"),
+                is(Arrays.asList(20, 21)));
+        
+        // check that the largest value was expired
+        assertThat("incorrect access groups", cache.findAccessGroupIds("foo"),
+                is(Arrays.asList(2, 3)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("bar"),
+                is(Arrays.asList(6, 7, 8, 9)));
+        assertThat("incorrect access groups", cache.findAccessGroupIds("baz"),
+                is(Arrays.asList(20, 21)));
+    }
+    
+    @Test
+    public void constructFail() throws Exception {
+        final AccessGroupProvider wrapped = mock(AccessGroupProvider.class);
+        failConstruct(null, 10, 10, new NullPointerException("provider"));
+        failConstruct(wrapped, 0, 10,
+                new IllegalArgumentException("cache lifetime must be at least one second"));
+        failConstruct(wrapped, 10, 0,
+                new IllegalArgumentException("cache size must be at least one"));
+    }
+
+    private void failConstruct(
+            final AccessGroupProvider provider,
+            final int lifetimeSec,
+            final int size,
+            final Exception exception) {
+        try {
+            new AccessGroupCache(provider, lifetimeSec, size);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, exception);
+        }
+    }
+    
+    @Test
+    public void getFailIOE() throws Exception {
+        final AccessGroupProvider wrapped = mock(AccessGroupProvider.class);
+        final AccessGroupCache cache = new AccessGroupCache(wrapped, 10000, 10);
+        
+        when(wrapped.findAccessGroupIds("foo")).thenThrow(new IOException("well poop"));
+        
+        failFindAccessGroupIDs(cache, "foo", new IOException("well poop"));
+    }
+    
+    private void failFindAccessGroupIDs(
+            final AccessGroupCache cache,
+            final String user,
+            final Exception expected) {
+        try {
+            cache.findAccessGroupIds(user);
+            fail("expected exception");
+        } catch (Exception got) {
+            TestCommon.assertExceptionCorrect(got, expected);
+        }
+    }
+
+}

--- a/test/src/kbaserelationengine/events/storage/MongoDBStatusEventStorageTest.java
+++ b/test/src/kbaserelationengine/events/storage/MongoDBStatusEventStorageTest.java
@@ -63,7 +63,7 @@ public class MongoDBStatusEventStorageTest {
 
     @Test
     public void test02() throws IOException {
-        System.out.println(  mdStorage.findAccessGroupIds("WS", "psnovichkov") );
+        System.out.println(  mdStorage.findAccessGroupIds("psnovichkov") );
     }
 
 

--- a/test/src/kbaserelationengine/test/common/TestCommon.java
+++ b/test/src/kbaserelationengine/test/common/TestCommon.java
@@ -1,6 +1,12 @@
 package kbaserelationengine.test.common;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -198,5 +204,17 @@ public class TestCommon {
         ((ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
                 .getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME))
                 .setLevel(ch.qos.logback.classic.Level.OFF);
+    }
+    
+    public static void assertExceptionCorrect(
+            final Exception got,
+            final Exception expected) {
+        final StringWriter sw = new StringWriter();
+        got.printStackTrace(new PrintWriter(sw));
+        assertThat("incorrect exception. trace:\n" +
+                sw.toString(),
+                got.getLocalizedMessage(),
+                is(expected.getLocalizedMessage()));
+        assertThat("incorrect exception type", got, instanceOf(expected.getClass()));
     }
 }


### PR DESCRIPTION
Adds a cache for access group IDs per user. Expires based on
configurable time in cache and cache size. Cache is source agnostic and
wraps and presents the same AccessGroupProvider interface.

Now queries the workspace for private access groups rather than maintaining a local copy.

Tested manually.

On extremely limited data, search appears to be pretty fast - 31ms on a cache miss vs. 15ms on a cache hit when running RESKE and the workspace locally.

TODO:
* [x] use the cache
* [x] implement a workspace access provider and use